### PR TITLE
added link

### DIFF
--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -94,9 +94,16 @@ export default function Footer() {
               <ul className="space-y-2 text-sm">
                 {section.links.map((link) => (
                   <li key={link}>
-                    <a href="#" className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+                  {
+                    link==="Pricing"?(
+                  
+                  <a href="#pricing" className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
                       {link}
-                    </a>
+                    </a>):(
+                      <a href="#" className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+                      {link}
+                      </a>
+                    )}   
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION


https://github.com/user-attachments/assets/f98b06e4-7e02-493f-98c5-0997d9cba117

Before this ,only the pricing in navbar takes to the correct section,but the pricing in footer doesn't give correctly

After changes:
The pricing in both navbar and footer section goes to the correct section 