### PR TITLE
fix(ui): align pricing card buttons consistently

### DIFF
--- a/src/pages/PriceSection.tsx
+++ b/src/pages/PriceSection.tsx
@@ -139,7 +139,7 @@ export default function Pricing() {
               key={index}
               data-aos="zoom-in"
               data-aos-delay={index * 150}
-              className={`bg-white dark:bg-gray-800 rounded-2xl p-8 relative transform transition-transform duration-300 hover:rotate-x-2 hover:rotate-y-2 hover:scale-105 hover:shadow-xl dark:hover:shadow-gray-900/50 ${
+              className={`flex flex-col bg-white dark:bg-gray-800 rounded-2xl p-8 relative transform transition-transform duration-300 hover:rotate-x-2 hover:rotate-y-2 hover:scale-105 hover:shadow-xl dark:hover:shadow-gray-900/50 ${
                 plan.popular ? "ring-2 ring-primary-600 scale-105" : ""
               }`}
               style={{ transformStyle: "preserve-3d" }}
@@ -175,7 +175,7 @@ export default function Pricing() {
                 </p>
               </div>
 
-              <ul className="space-y-3 mb-8">
+              <ul className="space-y-3 mb-8 flex-1">
                 {plan.features.map((feature, idx) => (
                   <li
                     key={idx}


### PR DESCRIPTION
# 📌 Pull Request

## 📝 Description
Aligned action buttons in the pricing table cards. Previously, the Start New Trial button in the starter card sat higher than the buttons in the other cards, causing a UI inconsistency. Updated layout so all buttons align properly across all plans.

## 🔗 Related Issue(s)
Fixes #163

## 📄 Type of Change
- [ ] 🚀 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ♻️ Code Refactoring
- [x] 🎨 UI/UX Improvement
- [ ] ⚡ Performance Optimization
- [ ] ✅ Test Addition/Update

---

### 📋 Changes Made
<!-- Summarize the key changes in this PR -->
1. Updated pricing card container to flex flex-col.
2. Applied flex-1 to the features section of the pricing card so it expands and pushes the button to the bottom. 

---

## ✅ Checklist
- [x] My code follows the project’s coding guidelines
- [x] I have tested these changes locally
- [ ] Documentation has been updated (if applicable)
- [x] No new warnings or errors introduced
- [x] I have checked for and resolved merge conflicts

---

## 📷 Screenshots
<!-- Include before/after screenshots or GIFs to showcase changes -->
<img width="1770" height="830" alt="image" src="https://github.com/user-attachments/assets/e3d11eaa-3028-40fe-bdbd-7d3d58681b00" />

---

## 💬 Additional Notes
Mention any further changes if required regarding this UI fix. I will attend to them.
