### PR TITLE
UI Bug: CareSync Dashboard Panel Overlaps with Navigation Bar Fixed

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -144,7 +144,7 @@ const LandingPage = () => {
             </div>
             
             {/* Right Column - Dashboard Preview */}
-            <div className="relative">
+            <div className="relative p-4">
               {user ? (
                 // AUTHENTICATED: show professional dashboard preview
                 <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-6 border border-gray-100 dark:border-gray-700">
@@ -200,9 +200,9 @@ const LandingPage = () => {
                 </div>
               ) : (
                 // VISITOR: show professional dashboard preview
-                <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-6 border border-gray-100 dark:border-gray-700">
+                <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-3 border border-gray-100 dark:border-gray-700">
                   {/* Dashboard Header */}
-                  <div className="flex items-center justify-between mb-6 pb-4 border-b border-gray-100 dark:border-gray-700">
+                  <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-100 dark:border-gray-700">
                     <div className="flex items-center space-x-3">
                       <div className="w-10 h-10 gradient-accent rounded-lg flex items-center justify-center">
                         <HeartIcon className="h-6 w-6 text-white" />
@@ -357,11 +357,11 @@ const LandingPage = () => {
               )}
 
               {/* Subtle Decorative Elements */}
-              <div className="absolute -top-6 -left-6 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 p-4 rounded-2xl shadow-lg">
+              <div className="absolute -top-0 -left-10 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 p-4 rounded-2xl shadow-lg">
                 <HeartIcon className="h-8 w-8" />
               </div>
 
-              <div className="absolute -bottom-6 -right-6 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 p-4 rounded-2xl shadow-lg">
+              <div className="absolute -bottom-0 -right-10 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 p-4 rounded-2xl shadow-lg">
                 <ShieldCheckIcon className="h-8 w-8" />
               </div>
 


### PR DESCRIPTION
# 📌 Pull Request

## 📝 Description
<!--The CareSync Dashboard panel on the right side overlaps with the top navigation bar (navbar) on the homepage. This creates a layout inconsistency and reduces the readability of the heart icon.-->

## 🔗 Related Issue(s)
<!-- Link related issues here using `#159` -->
Fixes #159 

## 📄 Type of Change
- [ ] 🚀 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ♻️ Code Refactoring
- [x] 🎨 UI/UX Improvement
- [ ] ⚡ Performance Optimization
- [ ] ✅ Test Addition/Update

---

### 📋 Changes Made
<!-- Summarize the key changes in this PR -->
1. Adjust top margin/padding of the dashboard panel and decorative items.

---

## ✅ Checklist
- [x] My code follows the project’s coding guidelines
- [x] I have tested these changes locally
- [ ] Documentation has been updated (if applicable)
- [x] No new warnings or errors introduced
- [x] I have checked for and resolved merge conflicts

---

## 📷 Screenshots

Before
<img width="1826" height="906" alt="Screenshot 2025-08-17 010115" src="https://github.com/user-attachments/assets/30f67379-e072-4f66-bee2-e7a55e659028" />

After
<img width="1903" height="906" alt="Screenshot 2025-08-17 141252" src="https://github.com/user-attachments/assets/21cce251-a4c7-4bb5-bef3-830ac43d7a7d" />

---

## 💬 Additional Notes
<!-- Any other context or information reviewers should know -->
