### PR TITLE
fix(footer): update logo to original CareSync logo (#260)

### DIFF
--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -84,12 +84,14 @@ export default function Footer() {
       <div className="px-4 py-12 mx-auto max-w-7xl sm:px-6 lg:px-8">
         {/* Brand + Social (centered) */}
         <div className="flex flex-col items-center mb-10 space-y-4 text-center">
-          <div className="flex items-center justify-center">
-            <div className="flex items-center justify-center w-10 h-10 shadow-lg bg-gradient-to-r from-emerald-500 to-teal-600 rounded-xl">
-              <HeartIcon className="w-6 h-6 text-white" />
-            </div>
-            <span className="ml-2 text-xl font-bold">CareSync</span>
-          </div>
+        <div className="flex items-center justify-center">
+  <img
+    src="/CareSync-Logo.png"
+    alt="CareSync Logo"
+    className="h-12 object-contain"
+  />
+</div>
+
 
           <p className="max-w-md text-sm leading-relaxed text-gray-600 dark:text-gray-400">
             Revolutionizing healthcare through seamless collaboration between


### PR DESCRIPTION
### Summary
This pull request updates the footer logo to use the official CareSync logo for consistency across the project.

### Changes Made
- Replaced the HeartIcon + text with the original CareSync logo image.
- Updated `src/pages/Footer.jsx` to reference `/CareSync-Logo.png` from the `public` directory.
- Ensured responsive sizing and alignment of the logo.

### Related Issue
Fixes #260

### Screenshots
<img width="613" height="245" alt="image" src="https://github.com/user-attachments/assets/7dba6deb-b421-47b2-9f6b-6fa243df49ce" />

