### PR TITLE
[UI] fix navbar links on signup/login pages - issue #310

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Bars3Icon, MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useAuth } from "../../contexts/AuthContext";
@@ -13,6 +13,10 @@ const Navbar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const { isDark, toggleTheme } = useTheme();
   const { user } = useAuth();
+  const location = useLocation();
+  
+  // check if current page is login or register
+  const isAuthPage = location.pathname === '/login' || location.pathname === '/register';
   
   // Define section IDs for scroll spy
   const sectionIds = ['home', 'features', 'pricing', 'testimonials', 'contact-form'];
@@ -28,72 +32,97 @@ const Navbar = () => {
     }
   }, [isMobileMenuOpen]);
 
-  const menuItems = [
-    { name: "Home", id: "home" },
-    { name: "Features", id: "features" },
-    { name: "Pricing", id: "pricing" },
-    { name: "Testimonials", id: "testimonials" },
-    { name: "Contact", id: "contact-form" }
-  ];
+  // show only home link on auth pages
+  const menuItems = isAuthPage 
+    ? [{ name: "Home", id: "home" }]
+    : [
+        { name: "Home", id: "home" },
+        { name: "Features", id: "features" },
+        { name: "Pricing", id: "pricing" },
+        { name: "Testimonials", id: "testimonials" },
+        { name: "Contact", id: "contact-form" }
+      ];
 
   return (
     <nav className="fixed top-0 w-full bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg border-b border-gray-200/50 dark:border-gray-800/50 z-50 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          {/* Logo with smooth scroll functionality */}
-          <a
-            key="Home"
-            href="#home"
-            onClick={(e) => {
-              e.preventDefault();
-              document.getElementById('home')?.scrollIntoView({ behavior: 'smooth' });
-            }}
-          >   
-            <div className="flex items-center">
-              <div className="w-10 h-10">
-                <img
-                  src="/CareSync-Logo.png"
-                  alt="CareSync Logo"
-                  className="w-full h-full"
-                />
+          {/* Logo and Home link section */}
+          <div className="flex items-center space-x-6">
+            <a
+              key="Logo"
+              href={isAuthPage ? "/" : "#home"}
+              onClick={(e) => {
+                e.preventDefault();
+                if (isAuthPage) {
+                  navigate('/');
+                } else {
+                  document.getElementById('home')?.scrollIntoView({ behavior: 'smooth' });
+                }
+              }}
+            >   
+              <div className="flex items-center">
+                <div className="w-10 h-10">
+                  <img
+                    src="/CareSync-Logo.png"
+                    alt="CareSync Logo"
+                    className="w-full h-full"
+                  />
+                </div>
+                <span
+                  className="ml-3 font-bold text-emerald-600 dark:text-emerald-400"
+                  style={{ fontSize: "1.375rem" }}
+                >
+                  CareSync
+                </span>
               </div>
-              <span
-                className="ml-3 font-bold text-emerald-600 dark:text-emerald-400"
-                style={{ fontSize: "1.375rem" }}
-              >
-                CareSync
-              </span>
-            </div>
-          </a>
-
-          {/* Desktop Menu with scroll spy functionality */}
-          <div className="hidden md:flex items-center space-x-8">
-            {menuItems.map((item) => (
+            </a>
+            
+            {/* Home link on auth pages */}
+            {isAuthPage && (
               <a
-                key={item.id}
-                href={`#${item.id}`}
+                href="/"
                 onClick={(e) => {
                   e.preventDefault();
-                  document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth' });
+                  navigate('/');
                 }}
-                className={`relative transition-all duration-300 font-medium group px-2 py-1 rounded-md ${
-                  activeSection === item.id
-                    ? "text-emerald-600 dark:text-emerald-400 font-semibold drop-shadow-sm bg-emerald-50 dark:bg-emerald-900/20"
-                    : "text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-                }`}
+                className="text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium"
               >
-                {item.name}
-                <span 
-                  className={`absolute left-0 -bottom-1 h-[2px] bg-emerald-600 transition-all duration-300 ${
-                    activeSection === item.id ? "w-full" : "w-0 group-hover:w-full"
-                  }`} 
-                />
-                {activeSection === item.id && (
-                  <span className="absolute -top-1 -right-1 w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
-                )}
+                Home
               </a>
-            ))}
+            )}
           </div>
+
+          {/* Desktop Menu with navigation functionality */}
+          {!isAuthPage && (
+            <div className="hidden md:flex items-center space-x-8">
+              {menuItems.map((item) => (
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth' });
+                  }}
+                  className={`relative transition-all duration-300 font-medium group px-2 py-1 rounded-md ${
+                    activeSection === item.id
+                      ? "text-emerald-600 dark:text-emerald-400 font-semibold drop-shadow-sm bg-emerald-50 dark:bg-emerald-900/20"
+                      : "text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  }`}
+                >
+                  {item.name}
+                  <span 
+                    className={`absolute left-0 -bottom-1 h-[2px] bg-emerald-600 transition-all duration-300 ${
+                      activeSection === item.id ? "w-full" : "w-0 group-hover:w-full"
+                    }`} 
+                  />
+                  {activeSection === item.id && (
+                    <span className="absolute -top-1 -right-1 w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
+                  )}
+                </a>
+              ))}
+            </div>
+          )}
 
 
           {/* Mobile Menu Button */}
@@ -162,7 +191,7 @@ const Navbar = () => {
             {menuItems.map((item) => (
               <a
                 key={item.id}
-                href={`#${item.id}`}
+                href={isAuthPage ? "/" : `#${item.id}`}
                 className={`block text-center py-3 transition-all duration-300 font-medium relative group
                 after:content-[''] after:absolute after:left-0 after:bottom-1 after:h-[2px] after:w-full after:bg-emerald-600 after:scale-x-0 after:origin-center after:transition-transform after:duration-300
                 hover:after:scale-x-100 ${
@@ -170,7 +199,15 @@ const Navbar = () => {
                     ? "text-emerald-600 dark:text-emerald-400 after:scale-x-100 bg-emerald-50 dark:bg-emerald-900/20 font-semibold shadow-sm"
                     : "text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400"
                 }`}
-                onClick={() => setIsMobileMenuOpen(false)}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsMobileMenuOpen(false);
+                  if (isAuthPage) {
+                    navigate('/');
+                  } else {
+                    document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth' });
+                  }
+                }}
               >
                 {item.name}
               </a>


### PR DESCRIPTION
# Pull Request

## Description
Fixed navbar links on signup/login pages where navigation links were non-functional. On /register and /login pages, the navbar now shows only a "Home" link positioned next to the logo, and all navigation elements (logo, CareSync name, Home link) properly redirect to the homepage.

## Related Issue(s)
Fixes #310

## Type of Change
-> [✓] UI/UX Improvement
-> [ ] New Feature
-> [ ] Bug Fix
-> [ ] Documentation Update
-> [ ] Code Refactoring
-> [ ] Performance Optimization
-> [ ] Test Addition/Update

---

### Changes Made
1. Added route detection using useLocation hook to identify auth pages (/login, /register)
2. Conditionally display only "Home" link in navbar on signup/login pages
3. Repositioned Home link to left side next to logo instead of center
4. Updated navigation logic so logo, CareSync name, and Home link navigate to homepage on auth pages
5. Maintained original scroll behavior on homepage for all section links

---

## Checklist
-> [✓] My code follows the project's coding guidelines
-> [✓] I have tested these changes locally
-> [✓] Documentation has been updated (if applicable)
-> [✓] No new warnings or errors introduced
-> [✓] I have checked for and resolved merge conflicts

---

##Video


https://github.com/user-attachments/assets/54638b54-84d0-4f63-80fe-c63123ffc093


---

## Additional Notes
This fix ensures consistent navigation across the site and prevents users from getting stuck on signup/login pages.