### PR TITLE
Fix: Footer links scroll to top on navigation

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-e755d862'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.hqoc034hev"
+    "revision": "0.1fkmt9f2t5"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ import LicensePage from "./pages/License";
 import Contributors from "./components/common/Contributor";
 import ForgotPassword from "./pages/auth/ForgotPassword";
 import CursorBurst from "./components/common/CursorBurst"; // Import the new component
+import ScrollToTop from "./components/common/ScrollToTop";
 
 // Protected Route Component
 const ProtectedRoute = ({ children, requiredRole = null }) => {
@@ -256,6 +257,7 @@ function App() {
         <OfflineProvider>
           <MessageProvider>
             <Router>
+              <ScrollToTop />
               <div className="App bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100">
                 <AppRoutes />
                 <Toaster

--- a/src/components/common/ScrollToTop.jsx
+++ b/src/components/common/ScrollToTop.jsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+// This component ensures that navigation to a new page scrolls the window to the top.
+function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
# 📌 Pull Request

## 📝 Description
This pull request resolves a user experience issue where navigating via footer links would load the new page content but leave the user's viewport at the bottom of the page. This change implements a global solution that automatically scrolls the window to the top on every route change, ensuring a smooth and expected navigation flow.

## 🔗 Related Issue(s)
Fixes #351

## 📄 Type of Change
- [ ] 🚀 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ♻️ Code Refactoring
- [x] 🎨 UI/UX Improvement
- [ ] ⚡ Performance Optimization
- [ ] ✅ Test Addition/Update

---

### 📋 Changes Made
1. Created a new reusable `ScrollToTop.jsx` component in `src/components/common/`.
2. The component utilizes the `useLocation` hook from `react-router-dom` to detect when the URL pathname changes.
3. An `useEffect` hook was used to call `window.scrollTo(0, 0)` whenever the pathname changes.
4. Imported and placed the `<ScrollToTop />` component within the `<Router>` in `App.jsx` to apply the fix across the entire application.

---

## ✅ Checklist
- [x] My code follows the project’s coding guidelines
- [x] I have tested these changes locally
- [ ] Documentation has been updated (if applicable)
- [x] No new warnings or errors introduced
- [x] I have checked for and resolved merge conflicts

---

## 📷 Screenshots (if applicable)
Google Drive link for the screen recording of the implemented solution:
https://drive.google.com/file/d/1KwN-Ky68omm2trg2iTcaUCdB4f8tYoZ-/view?usp=sharing

---

## 💬 Additional Notes
This solution is implemented globally, so it should also resolve any similar scrolling issues for other links in the application, not just the footer.