### PR TITLE
Fix: adjust scroll-to-top button spacing

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,9 +82,7 @@ define(['./workbox-e755d862'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-
-    "revision": "0.1fkmt9f2t5"
-
+    "revision": "0.i3hgdoidrq"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -75,7 +75,7 @@ export default function Footer() {
       {isVisible && (
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          className="fixed z-50 w-10 h-10 p-2 mb-16 text-xl font-bold text-white transition rounded-lg cursor-pointer bottom-8 right-8 bg-gradient-to-r from-medical-500 to-primary-600 hover:from-primary-500 hover:to-medical-600 hover:scale-110"
+          className="fixed z-50 w-10 h-10 p-2 mb-6 text-xl font-bold text-white transition rounded-lg cursor-pointer bottom-1 right-6 bg-gradient-to-r from-medical-500 to-primary-600 hover:from-primary-500 hover:to-medical-600 hover:scale-110"
         >
           <ChevronDoubleUpIcon />
         </button>


### PR DESCRIPTION
# 📌 Pull Request  

## 📝 Description  
This PR fixes the positioning issue of the scroll-to-top button by moving it closer to the bottom for better alignment and improved user experience.  

## 🔗 Related Issue(s)  
Fixes #<issue_number>  

## 📄 Type of Change  
- [ ] 🚀 New Feature  
- [x] 🐛 Bug Fix  
- [ ] 📝 Documentation Update  
- [ ] ♻️ Code Refactoring  
- [x] 🎨 UI/UX Improvement  
- [ ] ⚡ Performance Optimization  
- [ ] ✅ Test Addition/Update  

---  

### 📋 Changes Made  
1. Removed unnecessary margin-bottom.  
2. Aligned the scroll-to-top button closer to the bottom.  
3. Verified responsiveness and ensured UI consistency.  

---  

## ✅ Checklist  
- [x] My code follows the project’s coding guidelines  
- [x] I have tested these changes locally  
- [ ] Documentation has been updated (if applicable)  
- [x] No new warnings or errors introduced  
- [x] I have checked for and resolved merge conflicts  

---  

## 📷 Screenshots (if applicable)  
*(Insert before/after screenshot showing button alignment change)*  
Before - 
<img width="1280" height="670" alt="image" src="https://github.com/user-attachments/assets/25c8be98-350d-4179-854c-764dad724e23" />

After - 
<img width="1192" height="596" alt="image" src="https://github.com/user-attachments/assets/5ea21ac2-4638-461d-b6e9-b21bad32850e" />

---  

## 💬 Additional Notes  
N/A  
