### PR TITLE
Fix: fixed Missing imports in HealthLogs component

### DIFF
--- a/src/components/patient/HealthLogs.jsx
+++ b/src/components/patient/HealthLogs.jsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { PlusIcon, PencilSquareIcon, TrashIcon, FunnelIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
+import jsPDF from "jspdf";
+import autoTable from "jspdf-autotable";
 
 import { predefinedTypes, vitalTypes } from '../../data/vitals.jsx'
 import {VitalInput} from "../../data/vitalInput.jsx"


### PR DESCRIPTION
The exportPDF() function used jsPDF and autoTable without importing them, which would cause a runtime error when trying to export PDF reports.
fixed it by adding the required imports
